### PR TITLE
Handle the case of searching for terms longer than 2000 characters

### DIFF
--- a/django/data/views.py
+++ b/django/data/views.py
@@ -56,7 +56,8 @@ def build_query(direction, filterValues, filters, order_by, search_term, source,
     # if there are multiple filters given then AND them:
     # the row must match all the filters
     if filters:
-        query = query.filter(**dict(zip(filters, ["{0}{1}{0}".format(quotes, v) for v in filterValues])))
+        query = query.filter(**dict(zip(["{0}__startswith".format(f) for f in filters],
+                                        ["{0}{1}{0}".format(quotes, v) for v in filterValues])))
 
     # search using the tsvector column which represents our document made of all the columns
     if search_term:

--- a/js/VariantSearch.js
+++ b/js/VariantSearch.js
@@ -32,7 +32,6 @@ function getSuggestions(value, callback) {
 
 function renderSuggestion(suggestion, input) {
     var maxLengthToDisplay = 50;
-    input.indexOf(suggestion);
     return (
         <span>
             <strong>{suggestion.slice(0, input.length)}</strong>

--- a/js/VariantSearch.js
+++ b/js/VariantSearch.js
@@ -31,13 +31,15 @@ function getSuggestions(value, callback) {
 }
 
 function renderSuggestion(suggestion, input) {
-    input.indexOf(suggestion)
+    var maxLengthToDisplay = 50;
+    input.indexOf(suggestion);
     return (
         <span>
             <strong>{suggestion.slice(0, input.length)}</strong>
-            {suggestion.slice(input.length)}
+            {suggestion.slice(input.length, maxLengthToDisplay)}
+            {(suggestion.length > maxLengthToDisplay) ? "..." : ""}
         </span>
-   );
+    );
 }
 
 var VariantSearch = React.createClass({

--- a/js/backend.js
+++ b/js/backend.js
@@ -29,7 +29,6 @@ function trimSearchTerm(search) {
 // XXX these defaults might produce odd user experience, since they
 // are not reflected in the UI.
 function url(opts) {
-    console.log(opts)
     var {
         format = 'json',
         filterValues = {},

--- a/js/backend.js
+++ b/js/backend.js
@@ -13,9 +13,23 @@ var databaseUrl = "http://brcaexchange.cloudapp.net/backend";
 
 var transpose = a => _.zip.apply(_, a);
 
+// URIs have a 2083 character size limit and some search terms exceed that.
+// Limit the length and cut at a semicolon if possible to ensure the search works
+function trimSearchTerm(search) {
+    if (search.length > 50) {
+        search = search.slice(0, 50);
+        var lastSemicolonPosition = search.lastIndexOf(":");
+        if (lastSemicolonPosition !== -1) {
+            search = search.slice(0, lastSemicolonPosition);
+        }
+    }
+    return search;
+}
+
 // XXX these defaults might produce odd user experience, since they
 // are not reflected in the UI.
 function url(opts) {
+    console.log(opts)
     var {
         format = 'json',
         filterValues = {},
@@ -27,6 +41,7 @@ function url(opts) {
         } = opts,
 
         [filter, filterValue] = transpose(_.pairs(_.pick(filterValues, v => v)));
+    search = trimSearchTerm(search);
 
     return `${databaseUrl}/data/?${qs.stringify(_.pick({
         format,
@@ -47,5 +62,6 @@ function data(opts) {
 
 module.exports = {
     data,
-    url
+    url,
+    trimSearchTerm
 };

--- a/js/backend.js
+++ b/js/backend.js
@@ -18,9 +18,9 @@ var transpose = a => _.zip.apply(_, a);
 function trimSearchTerm(search) {
     if (search.length > 50) {
         search = search.slice(0, 50);
-        var lastSemicolonPosition = search.lastIndexOf(":");
-        if (lastSemicolonPosition !== -1) {
-            search = search.slice(0, lastSemicolonPosition);
+        var lastColonPosition = search.lastIndexOf(":");
+        if (lastColonPosition !== -1) {
+            search = search.slice(0, lastColonPosition);
         }
     }
     return search;

--- a/js/index.js
+++ b/js/index.js
@@ -305,7 +305,7 @@ function urlFromDatabase(state) {
         hide = _.keys(_.pick(columnSelection, v => !v)),
         [filter, filterValue] = transpose(_.pairs(_.pick(filterValues, v => v)));
     return _.pick({
-        search: search === '' ? null : search,
+        search: search === '' ? null : backend.trimSearchTerm(search),
         filter,
         filterValue,
         page: page === 0 ? null : page,
@@ -322,6 +322,7 @@ var Database = React.createClass({
     // getQuery().
     mixins: [Navigation, State],
     showVariant: function (row) {
+        row.Genomic_Coordinate = backend.trimSearchTerm(row.Genomic_Coordinate);
         this.transitionTo(`/variant/${variantPathJoin(row)}`);
     },
     showHelp: function (title) {


### PR DESCRIPTION
Some times autocomplete suggests very long coordingates that exceed the uri size limit. This trims such long search terms, and also handles the case of clicking a table row with a long filterValue.
I tested this by searching for chr17:41160094 and selecting the long suggestion, and then licking on the table row.