### PR TITLE
Used different column names based on the mode

### DIFF
--- a/content/help_research.md
+++ b/content/help_research.md
@@ -1,3 +1,5 @@
+Placeholder for research mode help page
+
 # Searching
 
 Variants are identified using [HGVS nomenclature](http://www.hgvs.org/mutnomen/), a standard created by the Human Genome Variation Society.  Most genetic test results are reported in HGVS nomenclature. This nomenclature describes a variant by indicating (1) a reference sequence, (2) what kind of sequence it is (genomic, cDNA or protein), (3) the position of the variant in relation this reference sequence, and (4) the nucloetide or protein differences between the variant and the reference sequence.  For example, _NM_007294.3:c.5053A>G_ indicates a variant relative to reference sequence _NM_007294.3_, which is a cDNA sequence (as indicated by _c_), that the variant is in position 5053, and that it involves changing an _A_ to a _G_.  

--- a/js/DataTable.js
+++ b/js/DataTable.js
@@ -70,14 +70,13 @@ var DataTable = React.createClass({
         this.fetch(this.state);
     },
     getInitialState: function () {
-        var defaultColumns = ['Gene_symbol', 'Genomic_Coordinate', 'HGVS_cDNA', 'HGVS_protein', 'Abbrev_AA_change', 'BIC_Nomenclature', 'Clinical_significance'];
         return mergeState({
             data: [],
             lollipopOpen: false,
             filtersOpen: false,
             filterValues: {},
             search: '',
-            columnSelection: _.object(_.map(this.props.columns, c => _.contains(defaultColumns, c.prop) ? [c.prop, true] : [c.prop, false])),
+            columnSelection: _.object(_.map(this.props.columns, c => _.contains(this.props.defaultColumns, c.prop) ? [c.prop, true] : [c.prop, false])),
             sourceSelection: this.props.source,
             pageLength: 20,
             page: 0,
@@ -184,7 +183,7 @@ var DataTable = React.createClass({
     render: function () {
         var {filterValues, filtersOpen, lollipopOpen, search, data, columnSelection, sourceSelection,
             page, totalPages, count, error} = this.state;
-        var {columns, filterColumns, suggestions, className, subColumns, source} = this.props;
+        var {columns, filterColumns, className, subColumns, source} = this.props;
         var renderColumns = _.filter(columns, c => columnSelection[c.prop]);
         var filterFormEls = _.map(filterColumns, ({name, prop, values}) =>
             <SelectField onChange={v => this.setFilters({[prop]: filterAny(v)})}
@@ -257,7 +256,6 @@ var DataTable = React.createClass({
                     <Col sm={5}>
                         <VariantSearch
                             id='variants-search'
-                            suggestions={suggestions}
                             value={search}
                             onChange={v => {
                                 // reset the page number to zero on new searches

--- a/js/VariantTable.js
+++ b/js/VariantTable.js
@@ -72,12 +72,12 @@ var filterColumns = [
 
 var columns = [
     {title: 'Gene', prop: 'Gene_symbol'},
-    {title: 'Alternate Identifier (Genomic Coordinate)', prop: 'Genomic_Coordinate'},
-    {title: 'Identifier (HGVS cDNA)', prop: 'HGVS_cDNA'},
-    {title: 'Alternate Identifier (HGVS protein)', prop: 'HGVS_protein',},
-    {title: 'Alternate Identifier (HGVS protein (abbr))', prop: "Abbrev_AA_change"},
-    {title: 'Alternate Identifier (BIC nomenclature)', prop: "BIC_Nomenclature"},
+    {title: 'Identifier', prop: 'HGVS_cDNA'},
+    {title: 'Alternate Identifier', prop: 'Genomic_Coordinate'},
+    {title: 'Alt ID', prop: "Abbrev_AA_change"},
     {title: 'Pathogenicity', prop: 'Clinical_significance'},
+    {title: 'Alternate Identifier (HGVS protein)', prop: 'HGVS_protein',},
+    {title: 'Alternate Identifier (BIC nomenclature)', prop: "BIC_Nomenclature"},
     {title: 'Allele frequency (1000 Genomes)', prop: 'Allele_frequency_1000_Genomes'},
     {title: 'SAS Allele frequency (1000 Genomes)', prop: 'SAS_Allele_frequency_1000_Genomes'},
     {title: 'EAS Allele frequency (1000 Genomes)', prop: 'EAS_Allele_frequency_1000_Genomes'},
@@ -214,8 +214,8 @@ var subColumns = [
     }
 ];
 
-var defaultColumns = ['Gene_symbol', 'Genomic_Coordinate', 'HGVS_cDNA', 'HGVS_protein', 'Abbrev_AA_change', 'BIC_Nomenclature', 'Clinical_significance', 'Date_last_evaluated', 'Assertion_method', 'Assertion_method_citation'];
-var defaultResearchColumns = ['Gene_symbol', 'Genomic_Coordinate', 'HGVS_cDNA', 'HGVS_protein', 'Abbrev_AA_change', 'BIC_Nomenclature', 'Clinical_significance'];
+var defaultColumns = ['Gene_symbol', 'HGVS_cDNA', 'Genomic_Coordinate', 'Abbrev_AA_change', 'Clinical_significance'];
+var defaultResearchColumns = ['Gene_symbol', 'HGVS_cDNA', 'Genomic_Coordinate', 'HGVS_protein', 'Abbrev_AA_change', 'BIC_Nomenclature', 'Clinical_significance'];
 
 var allSources = {
     Variant_in_ENIGMA: true,
@@ -243,9 +243,6 @@ var hasSelection = () => !(window.getSelection && window.getSelection().isCollap
 
 var Table = React.createClass({
     mixins: [PureRenderMixin],
-    getData: function () {
-        return this.refs.table.state.data;
-    },
     render: function () {
         var {data, onHeaderClick, onRowClick, hiddenSources,...opts} = this.props;
         return (
@@ -314,10 +311,7 @@ var VariantTableSupplier = function (Component) {
 };
 
 
-var VariantTable = VariantTableSupplier(Table);
-var ResearchVariantTable = ResearchVariantTableSupplier(Table);
-
 module.exports = ({
-    VariantTable: VariantTable,
-    ResearchVariantTable: ResearchVariantTable,
+    VariantTable: VariantTableSupplier(Table),
+    ResearchVariantTable: ResearchVariantTableSupplier(Table),
 });

--- a/js/VariantTable.js
+++ b/js/VariantTable.js
@@ -70,15 +70,15 @@ var filterColumns = [
 //    return sorted;
 //}
 
-
+//Some columns appear under a different name on the table header and the detail page
 var columns = [
     {title: 'Gene', prop: 'Gene_symbol'},
-    {title: 'Identifier', prop: 'HGVS_cDNA'},
-    {title: 'Alternate Identifier', prop: 'Genomic_Coordinate'},
-    {title: 'Alt ID', prop: "Abbrev_AA_change"},
+    {title: 'Identifier', prop: 'HGVS_cDNA', dp_title: 'Identifier (HGVS cDNA)'},
+    {title: 'Alternate Identifier', prop: 'Genomic_Coordinate', dp_title: 'Alternate Identifier (Genomic Coordinate)'},
+    {title: 'Alt ID', prop: "Abbrev_AA_change", dp_title: 'Alternate Identifier (HGVS protein (abbr))'},
     {title: 'Pathogenicity', prop: 'Clinical_significance'},
     {title: 'Alternate Identifier (HGVS protein)', prop: 'HGVS_protein'},
-    {title: 'Alternate Identifier (BIC nomenclature)', prop: "BIC_Nomenclature"},
+    {title: 'Alternate Identifier (BIC nomenclature)', prop: "BIC_Nomenclature"}
 ];
 
 var research_mode_columns = [

--- a/js/VariantTable.js
+++ b/js/VariantTable.js
@@ -70,43 +70,15 @@ var filterColumns = [
 //    return sorted;
 //}
 
+
 var columns = [
     {title: 'Gene', prop: 'Gene_symbol'},
     {title: 'Identifier', prop: 'HGVS_cDNA'},
     {title: 'Alternate Identifier', prop: 'Genomic_Coordinate'},
     {title: 'Alt ID', prop: "Abbrev_AA_change"},
     {title: 'Pathogenicity', prop: 'Clinical_significance'},
-    {title: 'Alternate Identifier (HGVS protein)', prop: 'HGVS_protein',},
+    {title: 'Alternate Identifier (HGVS protein)', prop: 'HGVS_protein'},
     {title: 'Alternate Identifier (BIC nomenclature)', prop: "BIC_Nomenclature"},
-    {title: 'Allele frequency (1000 Genomes)', prop: 'Allele_frequency_1000_Genomes'},
-    {title: 'SAS Allele frequency (1000 Genomes)', prop: 'SAS_Allele_frequency_1000_Genomes'},
-    {title: 'EAS Allele frequency (1000 Genomes)', prop: 'EAS_Allele_frequency_1000_Genomes'},
-    {title: 'AMR Allele frequency (1000 Genomes)', prop: 'AMR_Allele_frequency_1000_Genomes'},
-    {title: 'EUR Allele frequency (1000 Genomes)', prop: 'EUR_Allele_frequency_1000_Genomes'},
-    {title: 'AFR Allele frequency (1000 Genomes)', prop: 'AFR_Allele_frequency_1000_Genomes'},
-    {title: 'Allele origin (ClinVar)', prop: 'Allele_origin_ClinVar'},
-    {title: 'Variant clinical significance (ClinVar)', prop: 'Variant_clinical_significance_ClinVar'},
-    {title: 'HGVS genomic (LOVD)', prop: 'HGVS_genomic_LOVD'},
-    {title: 'Origin of variant (LOVD)', prop: 'Origin_of_variant_LOVD'},
-    {title: 'HGVS protein (LOVD)', prop: 'HGVS_protein_LOVD'},
-    {title: 'Variant frequency (LOVD)', prop: 'Variant_frequency_LOVD'},
-    {title: 'HGVS cDNA (LOVD)', prop: 'HGVS_cDNA_LOVD'},
-    {title: 'Variant affecting protein (LOVD)', prop: 'Variant_affecting_protein_LOVD'},
-    {title: 'Variant haplotype (LOVD)', prop: 'Variant_haplotype_LOVD'},
-    {title: 'VEP Gene (ExAC)', prop: 'VEP_Gene_ExAC'},
-    {title: 'Allele frequency (ExAC)', prop: 'Allele_frequency_ExAC'},
-    {title: 'VEP HGVSc (ExAC)', prop: 'VEP_HGVSc_ExAC'},
-    {title: 'VEP Consequence (ExAC)', prop: 'VEP_Consequence_ExAC'},
-    {title: 'VEP HGVSp (ExAC)', prop: 'VEP_HGVSp_ExAC'},
-    {title: 'Exon number (exLOVD)', prop: 'Exon_number_exLOVD'},
-    {title: 'IARC class (exLOVD)', prop: 'IARC_class_exLOVD'},
-    {title: 'BIC (exLOVD)', prop: 'BIC_exLOVD'},
-    {title: 'HGVS cDNA (exLOVD)', prop: 'HGVS_cDNA_exLOVD'},
-    {title: 'Literature source (exLOVD)', prop: 'Literature_source_exLOVD'},
-    {title: 'HGVS protein (exLOVD)', prop: 'HGVS_protein_exLOVD'},
-    {title: 'Date last evaluated', prop: 'Date_last_evaluated'},
-    {title: 'Assertion method', prop: 'Assertion method'},
-    {title: 'Assertion method citation', prop: 'Assertion_method_citation'},
 ];
 
 var research_mode_columns = [
@@ -146,6 +118,8 @@ var research_mode_columns = [
     {title: 'Date last evaluated', prop: 'Date_last_evaluated'},
     {title: 'Assertion method', prop: 'Assertion method'},
     {title: 'Assertion method citation', prop: 'Assertion_method_citation'},
+    {title: 'URL', prop: 'URL'}
+
 ];
 
 var subColumns = [
@@ -314,4 +288,6 @@ var VariantTableSupplier = function (Component) {
 module.exports = ({
     VariantTable: VariantTableSupplier(Table),
     ResearchVariantTable: ResearchVariantTableSupplier(Table),
+    research_mode_columns: research_mode_columns,
+    columns: columns
 });

--- a/js/VariantTable.js
+++ b/js/VariantTable.js
@@ -70,136 +70,151 @@ var filterColumns = [
 //}
 
 var columns = [
-    {title: 'Gene', prop: 'Gene_symbol', render: renderCell},
-    {title: 'Genomic Coordinate', prop: 'Genomic_Coordinate', render: renderCell},
-    {title: 'HGVS cDNA', prop: 'HGVS_cDNA', /*sortFn: posCmpFn, */render: renderCell},
-    {title: 'HGVS protein', prop: 'HGVS_protein', /*sortFn: posCmpFn, */render: renderCell},
-    {title: 'HGVS protein (Abbrev.)', prop: "Abbrev_AA_change", render: renderCell},
-    {title: 'BIC nucleotide', prop: "BIC_Nomenclature", render: renderCell},
-    {title: 'Pathogenicity', prop: 'Clinical_significance', render: renderCell},
-    {title: 'Allele frequency (1000 Genomes)', prop: 'Allele_frequency_1000_Genomes', render: renderCell},
-    {title: 'SAS Allele frequency (1000 Genomes)', prop: 'SAS_Allele_frequency_1000_Genomes', render: renderCell},
-    {title: 'EAS Allele frequency (1000 Genomes)', prop: 'EAS_Allele_frequency_1000_Genomes', render: renderCell},
-    {title: 'AMR Allele frequency (1000 Genomes)', prop: 'AMR_Allele_frequency_1000_Genomes', render: renderCell},
-    {title: 'EUR Allele frequency (1000 Genomes)', prop: 'EUR_Allele_frequency_1000_Genomes', render: renderCell},
-    {title: 'AFR Allele frequency (1000 Genomes)', prop: 'AFR_Allele_frequency_1000_Genomes', render: renderCell},
-    {title: 'Allele origin (ClinVar)', prop: 'Allele_origin_ClinVar', render: renderCell},
-    {title: 'Variant clinical significance (ClinVar)', prop: 'Variant_clinical_significance_ClinVar', render: renderCell},
-    {title: 'HGVS genomic (LOVD)', prop: 'HGVS_genomic_LOVD', render: renderCell},
-    {title: 'Origin of variant (LOVD)', prop: 'Origin_of_variant_LOVD', render: renderCell},
-    {title: 'HGVS protein (LOVD)', prop: 'HGVS_protein_LOVD', render: renderCell},
-    {title: 'Variant frequency (LOVD)', prop: 'Variant_frequency_LOVD', render: renderCell},
-    {title: 'HGVS cDNA (LOVD)', prop: 'HGVS_cDNA_LOVD', render: renderCell},
-    {title: 'Variant affecting protein (LOVD)', prop: 'Variant_affecting_protein_LOVD', render: renderCell},
-    {title: 'Variant haplotype (LOVD)', prop: 'Variant_haplotype_LOVD', render: renderCell},
-    {title: 'VEP Gene (ExAC)', prop: 'VEP_Gene_ExAC', render: renderCell},
-    {title: 'Allele frequency (ExAC)', prop: 'Allele_frequency_ExAC', render: renderCell},
-    {title: 'VEP HGVSc (ExAC)', prop: 'VEP_HGVSc_ExAC', render: renderCell},
-    {title: 'VEP Consequence (ExAC)', prop: 'VEP_Consequence_ExAC', render: renderCell},
-    {title: 'VEP HGVSp (ExAC)', prop: 'VEP_HGVSp_ExAC', render: renderCell},
-    {title: 'Exon number (exLOVD)', prop: 'Exon_number_exLOVD', render: renderCell},
-    {title: 'IARC class (exLOVD)', prop: 'IARC_class_exLOVD', render: renderCell},
-    {title: 'BIC (exLOVD)', prop: 'BIC_exLOVD', render: renderCell},
-    {title: 'HGVS cDNA (exLOVD)', prop: 'HGVS_cDNA_exLOVD', render: renderCell},
-    {title: 'Literature source (exLOVD)', prop: 'Literature_source_exLOVD', render: renderCell},
-    {title: 'HGVS protein (exLOVD)', prop: 'HGVS_protein_exLOVD', render: renderCell}
+    {title: 'Gene', prop: 'Gene_symbol'},
+    {title: 'Alternate Identifier (Genomic Coordinate)', prop: 'Genomic_Coordinate'},
+    {title: 'Identifier (HGVS cDNA)', prop: 'HGVS_cDNA'},
+    {title: 'Alternate Identifier (HGVS protein)', prop: 'HGVS_protein',},
+    {title: 'Alternate Identifier (HGVS protein (abbr))', prop: "Abbrev_AA_change"},
+    {title: 'Alternate Identifier (BIC nomenclature)', prop: "BIC_Nomenclature"},
+    {title: 'Pathogenicity', prop: 'Clinical_significance'},
+    {title: 'Allele frequency (1000 Genomes)', prop: 'Allele_frequency_1000_Genomes'},
+    {title: 'SAS Allele frequency (1000 Genomes)', prop: 'SAS_Allele_frequency_1000_Genomes'},
+    {title: 'EAS Allele frequency (1000 Genomes)', prop: 'EAS_Allele_frequency_1000_Genomes'},
+    {title: 'AMR Allele frequency (1000 Genomes)', prop: 'AMR_Allele_frequency_1000_Genomes'},
+    {title: 'EUR Allele frequency (1000 Genomes)', prop: 'EUR_Allele_frequency_1000_Genomes'},
+    {title: 'AFR Allele frequency (1000 Genomes)', prop: 'AFR_Allele_frequency_1000_Genomes'},
+    {title: 'Allele origin (ClinVar)', prop: 'Allele_origin_ClinVar'},
+    {title: 'Variant clinical significance (ClinVar)', prop: 'Variant_clinical_significance_ClinVar'},
+    {title: 'HGVS genomic (LOVD)', prop: 'HGVS_genomic_LOVD'},
+    {title: 'Origin of variant (LOVD)', prop: 'Origin_of_variant_LOVD'},
+    {title: 'HGVS protein (LOVD)', prop: 'HGVS_protein_LOVD'},
+    {title: 'Variant frequency (LOVD)', prop: 'Variant_frequency_LOVD'},
+    {title: 'HGVS cDNA (LOVD)', prop: 'HGVS_cDNA_LOVD'},
+    {title: 'Variant affecting protein (LOVD)', prop: 'Variant_affecting_protein_LOVD'},
+    {title: 'Variant haplotype (LOVD)', prop: 'Variant_haplotype_LOVD'},
+    {title: 'VEP Gene (ExAC)', prop: 'VEP_Gene_ExAC'},
+    {title: 'Allele frequency (ExAC)', prop: 'Allele_frequency_ExAC'},
+    {title: 'VEP HGVSc (ExAC)', prop: 'VEP_HGVSc_ExAC'},
+    {title: 'VEP Consequence (ExAC)', prop: 'VEP_Consequence_ExAC'},
+    {title: 'VEP HGVSp (ExAC)', prop: 'VEP_HGVSp_ExAC'},
+    {title: 'Exon number (exLOVD)', prop: 'Exon_number_exLOVD'},
+    {title: 'IARC class (exLOVD)', prop: 'IARC_class_exLOVD'},
+    {title: 'BIC (exLOVD)', prop: 'BIC_exLOVD'},
+    {title: 'HGVS cDNA (exLOVD)', prop: 'HGVS_cDNA_exLOVD'},
+    {title: 'Literature source (exLOVD)', prop: 'Literature_source_exLOVD'},
+    {title: 'HGVS protein (exLOVD)', prop: 'HGVS_protein_exLOVD'},
+    {title: 'Date last evaluated', prop: 'Date_last_evaluated'},
+    {title: 'Assertion method', prop: 'Assertion method'},
+    {title: 'Assertion method citation', prop: 'Assertion_method_citation'},
+];
+
+var research_mode_columns = [
+    {title: 'Gene Symbol', prop: 'Gene_symbol'},
+    {title: 'Genomic Coordinate', prop: 'Genomic_Coordinate'},
+    {title: 'HGVS cDNA', prop: 'HGVS_cDNA'},
+    {title: 'HGVS protein', prop: 'HGVS_protein'},
+    {title: 'HGVS protein (Abbrev.)', prop: "Abbrev_AA_change"},
+    {title: 'BIC nucleotide', prop: "BIC_Nomenclature"},
+    {title: 'Clinical significance', prop: 'Clinical_significance'},
+    {title: 'Allele frequency (1000 Genomes)', prop: 'Allele_frequency_1000_Genomes'},
+    {title: 'SAS Allele frequency (1000 Genomes)', prop: 'SAS_Allele_frequency_1000_Genomes'},
+    {title: 'EAS Allele frequency (1000 Genomes)', prop: 'EAS_Allele_frequency_1000_Genomes'},
+    {title: 'AMR Allele frequency (1000 Genomes)', prop: 'AMR_Allele_frequency_1000_Genomes'},
+    {title: 'EUR Allele frequency (1000 Genomes)', prop: 'EUR_Allele_frequency_1000_Genomes'},
+    {title: 'AFR Allele frequency (1000 Genomes)', prop: 'AFR_Allele_frequency_1000_Genomes'},
+    {title: 'Allele origin (ClinVar)', prop: 'Allele_origin_ClinVar'},
+    {title: 'Variant clinical significance (ClinVar)', prop: 'Variant_clinical_significance_ClinVar'},
+    {title: 'HGVS genomic (LOVD)', prop: 'HGVS_genomic_LOVD'},
+    {title: 'Origin of variant (LOVD)', prop: 'Origin_of_variant_LOVD'},
+    {title: 'HGVS protein (LOVD)', prop: 'HGVS_protein_LOVD'},
+    {title: 'Variant frequency (LOVD)', prop: 'Variant_frequency_LOVD'},
+    {title: 'HGVS cDNA (LOVD)', prop: 'HGVS_cDNA_LOVD'},
+    {title: 'Variant affecting protein (LOVD)', prop: 'Variant_affecting_protein_LOVD'},
+    {title: 'Variant haplotype (LOVD)', prop: 'Variant_haplotype_LOVD'},
+    {title: 'VEP Gene (ExAC)', prop: 'VEP_Gene_ExAC'},
+    {title: 'Allele frequency (ExAC)', prop: 'Allele_frequency_ExAC'},
+    {title: 'VEP HGVSc (ExAC)', prop: 'VEP_HGVSc_ExAC'},
+    {title: 'VEP Consequence (ExAC)', prop: 'VEP_Consequence_ExAC'},
+    {title: 'VEP HGVSp (ExAC)', prop: 'VEP_HGVSp_ExAC'},
+    {title: 'Exon number (exLOVD)', prop: 'Exon_number_exLOVD'},
+    {title: 'IARC class (exLOVD)', prop: 'IARC_class_exLOVD'},
+    {title: 'BIC (exLOVD)', prop: 'BIC_exLOVD'},
+    {title: 'HGVS cDNA (exLOVD)', prop: 'HGVS_cDNA_exLOVD'},
+    {title: 'Literature source (exLOVD)', prop: 'Literature_source_exLOVD'},
+    {title: 'HGVS protein (exLOVD)', prop: 'HGVS_protein_exLOVD'},
+    {title: 'Date last evaluated', prop: 'Date_last_evaluated'},
+    {title: 'Assertion method', prop: 'Assertion method'},
+    {title: 'Assertion method citation', prop: 'Assertion_method_citation'},
 ];
 
 var subColumns = [
-    {subColTitle: "ENIGMA",
-     subColList: [
-        {title: 'Gene', prop: 'Gene_symbol', render: renderCell},
-        {title: 'Genomic Coordinate', prop: 'Genomic_Coordinate', render: renderCell},
-        {title: 'HGVS cDNA', prop: 'HGVS_cDNA', /*sortFn: posCmpFn, */render: renderCell},
-        {title: 'HGVS protein', prop: 'HGVS_protein', /*sortFn: posCmpFn, */render: renderCell},
-        {title: 'HGVS protein (Abbrev.)', prop: "Abbrev_AA_change", render: renderCell},
-        {title: 'BIC nucleotide', prop: "BIC_Nomenclature", render: renderCell},
-        {title: 'Pathogenicity', prop: 'Clinical_significance', render: renderCell}
-     ]
+    {
+        subColTitle: "ENIGMA",
+        subColList: [
+            {title: 'Gene', prop: 'Gene_symbol', render: renderCell},
+            {title: 'Genomic Coordinate', prop: 'Genomic_Coordinate', render: renderCell},
+            {title: 'HGVS cDNA', prop: 'HGVS_cDNA', /*sortFn: posCmpFn, */render: renderCell},
+            {title: 'HGVS protein', prop: 'HGVS_protein', /*sortFn: posCmpFn, */render: renderCell},
+            {title: 'HGVS protein (Abbrev.)', prop: "Abbrev_AA_change", render: renderCell},
+            {title: 'BIC nucleotide', prop: "BIC_Nomenclature", render: renderCell},
+            {title: 'Pathogenicity', prop: 'Clinical_significance', render: renderCell}
+        ]
     },
-    {subColTitle: "1000 Genomes",
-     subColList: [
-        {title: 'Allele frequency', prop: 'Allele_frequency_1000_Genomes', render: renderCell},
-        {title: 'SAS Allele frequency', prop: 'SAS_Allele_frequency_1000_Genomes', render: renderCell},
-        {title: 'EAS Allele frequency', prop: 'EAS_Allele_frequency_1000_Genomes', render: renderCell},
-        {title: 'AMR Allele frequency', prop: 'AMR_Allele_frequency_1000_Genomes', render: renderCell},
-        {title: 'EUR Allele frequency', prop: 'EUR_Allele_frequency_1000_Genomes', render: renderCell},
-        {title: 'AFR Allele frequency', prop: 'AFR_Allele_frequency_1000_Genomes', render: renderCell}
-     ]
+    {
+        subColTitle: "1000 Genomes",
+        subColList: [
+            {title: 'Allele frequency', prop: 'Allele_frequency_1000_Genomes', render: renderCell},
+            {title: 'SAS Allele frequency', prop: 'SAS_Allele_frequency_1000_Genomes', render: renderCell},
+            {title: 'EAS Allele frequency', prop: 'EAS_Allele_frequency_1000_Genomes', render: renderCell},
+            {title: 'AMR Allele frequency', prop: 'AMR_Allele_frequency_1000_Genomes', render: renderCell},
+            {title: 'EUR Allele frequency', prop: 'EUR_Allele_frequency_1000_Genomes', render: renderCell},
+            {title: 'AFR Allele frequency', prop: 'AFR_Allele_frequency_1000_Genomes', render: renderCell}
+        ]
     },
-    {subColTitle: 'ClinVar',
-     subColList: [
-        {title: 'Allele origin', prop: 'Allele_origin_ClinVar', render: renderCell},
-        {title: 'Variant clinical significance', prop: 'Variant_clinical_significance_ClinVar', render: renderCell}
-     ]
+    {
+        subColTitle: 'ClinVar',
+        subColList: [
+            {title: 'Allele origin', prop: 'Allele_origin_ClinVar', render: renderCell},
+            {title: 'Variant clinical significance', prop: 'Variant_clinical_significance_ClinVar', render: renderCell}
+        ]
     },
-    {subColTitle: 'LOVD',
-     subColList: [
-        {title: 'HGVS genomic', prop: 'HGVS_genomic_LOVD', render: renderCell},
-        {title: 'Origin of variant', prop: 'Origin_of_variant_LOVD', render: renderCell},
-        {title: 'HGVS protein', prop: 'HGVS_protein_LOVD', render: renderCell},
-        {title: 'Variant frequency', prop: 'Variant_frequency_LOVD', render: renderCell},
-        {title: 'HGVS cDNA', prop: 'HGVS_cDNA_LOVD', render: renderCell},
-        {title: 'Variant affecting protein', prop: 'Variant_affecting_protein_LOVD', render: renderCell},
-        {title: 'Variant haplotype', prop: 'Variant_haplotype_LOVD', render: renderCell}
-     ]
+    {
+        subColTitle: 'LOVD',
+        subColList: [
+            {title: 'HGVS genomic', prop: 'HGVS_genomic_LOVD', render: renderCell},
+            {title: 'Origin of variant', prop: 'Origin_of_variant_LOVD', render: renderCell},
+            {title: 'HGVS protein', prop: 'HGVS_protein_LOVD', render: renderCell},
+            {title: 'Variant frequency', prop: 'Variant_frequency_LOVD', render: renderCell},
+            {title: 'HGVS cDNA', prop: 'HGVS_cDNA_LOVD', render: renderCell},
+            {title: 'Variant affecting protein', prop: 'Variant_affecting_protein_LOVD', render: renderCell},
+            {title: 'Variant haplotype', prop: 'Variant_haplotype_LOVD', render: renderCell}
+        ]
     },
-    {subColTitle: 'ExAC',
-     subColList: [
-        {title: 'VEP Gene', prop: 'VEP_Gene_ExAC', render: renderCell},
-        {title: 'Allele frequency', prop: 'Allele_frequency_ExAC', render: renderCell},
-        {title: 'VEP HGVSc', prop: 'VEP_HGVSc_ExAC', render: renderCell},
-        {title: 'VEP Consequence', prop: 'VEP_Consequence_ExAC', render: renderCell},
-        {title: 'VEP HGVSp', prop: 'VEP_HGVSp_ExAC', render: renderCell}
-     ]
+    {
+        subColTitle: 'ExAC',
+        subColList: [
+            {title: 'VEP Gene', prop: 'VEP_Gene_ExAC', render: renderCell},
+            {title: 'Allele frequency', prop: 'Allele_frequency_ExAC', render: renderCell},
+            {title: 'VEP HGVSc', prop: 'VEP_HGVSc_ExAC', render: renderCell},
+            {title: 'VEP Consequence', prop: 'VEP_Consequence_ExAC', render: renderCell},
+            {title: 'VEP HGVSp', prop: 'VEP_HGVSp_ExAC', render: renderCell}
+        ]
     },
-    {subColTitle: 'exLOVD',
-     subColList: [
-        {title: 'Exon number', prop: 'Exon_number_exLOVD', render: renderCell},
-        {title: 'IARC class', prop: 'IARC_class_exLOVD', render: renderCell},
-        {title: 'BIC', prop: 'BIC_exLOVD', render: renderCell},
-        {title: 'HGVS cDNA', prop: 'HGVS_cDNA_exLOVD', render: renderCell},
-        {title: 'Literature source', prop: 'Literature_source_exLOVD', render: renderCell},
-        {title: 'HGVS protein', prop: 'HGVS_protein_exLOVD', render: renderCell}
-     ]
+    {
+        subColTitle: 'exLOVD',
+        subColList: [
+            {title: 'Exon number', prop: 'Exon_number_exLOVD', render: renderCell},
+            {title: 'IARC class', prop: 'IARC_class_exLOVD', render: renderCell},
+            {title: 'BIC', prop: 'BIC_exLOVD', render: renderCell},
+            {title: 'HGVS cDNA', prop: 'HGVS_cDNA_exLOVD', render: renderCell},
+            {title: 'Literature source', prop: 'Literature_source_exLOVD', render: renderCell},
+            {title: 'HGVS protein', prop: 'HGVS_protein_exLOVD', render: renderCell}
+        ]
     }
 ];
 
-var columnSelection = {
-    Gene_symbol: {selectVal: true},
-    Genomic_Coordinate: {selectVal: true},
-    HGVS_cDNA: {selectVal: true},
-    HGVS_protein: {selectVal: true},
-    Abbrev_AA_change: {selectVal: true},
-    BIC_Nomenclature: {selectVal: true},
-    Clinical_significance: {selectVal: true},
-    Allele_frequency_1000_Genomes: {selectVal: false},
-    SAS_Allele_frequency_1000_Genomes: {selectVal: false},
-    EAS_Allele_frequency_1000_Genomes: {selectVal: false},
-    AMR_Allele_frequency_1000_Genomes: {selectVal: false},
-    EUR_Allele_frequency_1000_Genomes: {selectVal: false},
-    AFR_Allele_frequency_1000_Genomes: {selectVal: false},
-    Allele_origin_ClinVar: {selectVal: false},
-    Variant_clinical_significance_ClinVar: {selectVal: false},
-    HGVS_genomic_LOVD: {selectVal: false},
-    Origin_of_variant_LOVD: {selectVal: false},
-    HGVS_protein_LOVD: {selectVal: false},
-    Variant_frequency_LOVD: {selectVal: false},
-    HGVS_cDNA_LOVD: {selectVal: false},
-    Variant_affecting_protein_LOVD: {selectVal: false},
-    Variant_haplotype_LOVD: {selectVal: false},
-    VEP_Gene_ExAC: {selectVal: false},
-    Allele_frequency_ExAC: {selectVal: false},
-    VEP_HGVSc_ExAC: {selectVal: false},
-    VEP_Consequence_ExAC: {selectVal: false},
-    VEP_HGVSp_ExAC: {selectVal: false},
-    Exon_number_exLOVD: {selectVal: false},
-    IARC_class_exLOVD: {selectVal: false},
-    BIC_exLOVD: {selectVal: false},
-    HGVS_cDNA_exLOVD: {selectVal: false},
-    Literature_source_exLOVD: {selectVal: false},
-    HGVS_protein_exLOVD: {selectVal: false}
-};
+var defaultColumns = ['Gene_symbol', 'Genomic_Coordinate', 'HGVS_cDNA', 'HGVS_protein', 'Abbrev_AA_change', 'BIC_Nomenclature', 'Clinical_significance', 'Date_last_evaluated', 'Assertion_method', 'Assertion_method_citation'];
+var defaultResearchColumns = ['Gene_symbol', 'Genomic_Coordinate', 'HGVS_cDNA', 'HGVS_protein', 'Abbrev_AA_change', 'BIC_Nomenclature', 'Clinical_significance'];
 
 var sources = {
     Variant_in_ENIGMA: true,
@@ -208,7 +223,7 @@ var sources = {
     Variant_in_ExAC: true,
     Variant_in_LOVD: true,
     Variant_in_BIC: true
-}
+};
 // Work-around to allow the user to select text in the table. The browser does not distinguish between
 // click and drag: if mouseup and mousedown occur on the same element, a click event is fired even if
 // the events occur at very different locations. That makes it hard to select text. This workaround
@@ -225,7 +240,7 @@ var sources = {
 // text areas to look clickable instead of selectable..
 var hasSelection = () => !(window.getSelection && window.getSelection().isCollapsed);
 
-var VariantTable = React.createClass({
+var Table = React.createClass({
     mixins: [PureRenderMixin],
     getData: function () {
         return this.refs.table.state.data;
@@ -240,9 +255,7 @@ var VariantTable = React.createClass({
                 buildRowOptions={r => ({title: 'click for details', onClick: () => hasSelection() ? null : onRowClick(r)})}
                 buildHeader={title => buildHeader(onHeaderClick, title)}
                 filterColumns={filterColumns}
-                columns={columns}
                 subColumns={subColumns}
-                columnSelection={columnSelection}
                 source={sources}
                 initialData={data}
                 initialPageLength={20}
@@ -253,5 +266,57 @@ var VariantTable = React.createClass({
     }
 });
 
+var ResearchVariantTableSupplier = function (Component) {
+    var ResearchVariantTableComponent = React.createClass({
+        mixins: [PureRenderMixin],
 
-module.exports = VariantTable;
+        getColumns: function () {
+            return research_mode_columns;
+        },
+        getDefaultColumns: function () {
+            return defaultResearchColumns;
+        },
+        render: function () {
+            return (
+                <Component
+                    {...this.props}
+                    columns={this.getColumns()}
+                    defaultColumns={this.getDefaultColumns()}
+                />
+            );
+        }
+    });
+    return ResearchVariantTableComponent;
+};
+
+var VariantTableSupplier = function (Component) {
+    var ResearchVariantTableComponent = React.createClass({
+        mixins: [PureRenderMixin],
+
+        getColumns: function () {
+            return columns;
+        },
+        getDefaultColumns: function () {
+            return defaultColumns;
+        },
+        render: function () {
+            return (
+                <Component
+                    {...this.props}
+                    columns={this.getColumns()}
+                    defaultColumns={this.getDefaultColumns()}
+                />
+            );
+        }
+    });
+    return ResearchVariantTableComponent;
+};
+
+
+var VariantTable = VariantTableSupplier(Table);
+var ResearchVariantTable = ResearchVariantTableSupplier(Table);
+
+module.exports = ({
+    VariantTable: VariantTable,
+    ResearchVariantTable: ResearchVariantTable,
+});

--- a/js/content.js
+++ b/js/content.js
@@ -7,6 +7,7 @@ var content = {
     history: require('../content/history.md'),
     variation: require('../content/variationAndCancer.md'),
     help: require('../content/help.md'),
+    help_research: require('../content/help_research.md'),
     disclaimer: require('../content/disclaimer.md'),
     thisSite: require('../content/thisSite.md')
 };

--- a/js/index.js
+++ b/js/index.js
@@ -230,15 +230,21 @@ var Help = React.createClass({
             }, 0);
         }
     },
-    render: function() {
+    render: function () {
         var fragment = slugify(window.location.hash.slice(1));
+        var helpContent;
+        if (localStorage.getItem("research-mode") === 'true') {
+            helpContent = content.pages.help_research;
+        } else {
+            helpContent = content.pages.help;
+        }
         return (
             <Grid className="help">
                 {fragment === '' ? null :
                     <style>{`#${fragment} { animation-name: emphasis; animation-duration: 10s; } `}</style>}
                 <Row>
                     <Col md={8} mdOffset={2}>
-                        <RawHTML ref='content' html={content.pages.help} />
+                        <RawHTML ref='content' html={helpContent}/>
                     </Col>
                 </Row>
             </Grid>

--- a/js/index.js
+++ b/js/index.js
@@ -396,9 +396,10 @@ var VariantDetail = React.createClass({
         } else {
             cols = columns;
         }
-        var rows = _.map(cols, ({prop, title}) => {
+        var rows = _.map(cols, ({prop, title, dp_title}) => {
+            var column_title = dp_title || title;
             return <tr key={prop}>
-                <Key tableKey={title} columns={cols} onClick={() => this.showHelp(title)}/>
+                <Key tableKey={column_title} columns={cols} onClick={() => this.showHelp(title)}/>
                 <td>{variant[prop]}</td>
             </tr>
         });

--- a/js/index.js
+++ b/js/index.js
@@ -321,7 +321,7 @@ var Database = React.createClass({
             params = databaseParams(this.getQuery());
         // XXX is 'keys' used?
         var table;
-        if (localStorage.getItem("research-mode") === true) {
+        if (localStorage.getItem("research-mode") === 'true') {
             table = <ResearchVariantTable
                 ref='table'
                 initialState={params}
@@ -385,7 +385,7 @@ var VariantDetail = React.createClass({
     render: function () {
         var {data: variant = {}, error} = this.state;
         var cols;
-        if (localStorage.getItem("research-mode") === true) {
+        if (localStorage.getItem("research-mode") === 'true') {
             cols = research_mode_columns;
         } else {
             cols = columns;

--- a/js/index.js
+++ b/js/index.js
@@ -30,8 +30,7 @@ var databaseKey = require('../databaseKey');
 var {Grid, Col, Row, Navbar, Nav, Table,
     DropdownButton, MenuItem, Modal, Button} = require('react-bootstrap');
 
-
-var VariantTable = require('./VariantTable');
+var {VariantTable, ResearchVariantTable} = require('./VariantTable');
 var VariantSearch = require('./VariantSearch');
 var {Navigation, State, Link, Route, RouteHandler,
     HistoryLocation, run, DefaultRoute} = require('react-router');
@@ -352,19 +351,33 @@ var Database = React.createClass({
         var {show} = this.props,
             params = databaseParams(this.getQuery());
         // XXX is 'keys' used?
+        var table;
+        if (localStorage.getItem("research-mode") === true) {
+            table = <ResearchVariantTable
+                ref='table'
+                initialState={params}
+                {...params}
+                fetch={backend.data}
+                url={backend.url}
+                onChange={s => this.urlq.onNext(s)}
+                keys={databaseKey}
+                onHeaderClick={this.showHelp}
+                onRowClick={this.showVariant}/>
+        } else {
+            table = <VariantTable
+                ref='table'
+                initialState={params}
+                {...params}
+                fetch={backend.data}
+                url={backend.url}
+                onChange={s => this.urlq.onNext(s)}
+                keys={databaseKey}
+                onHeaderClick={this.showHelp}
+                onRowClick={this.showVariant}/>
+        }
         return (
             <Grid style={{display: show ? 'block' : 'none'}}>
-                <VariantTable
-                    ref='table'
-                    initialState={params}
-                    {...params}
-                    fetch={backend.data}
-                    url={backend.url}
-                    onChange={s => this.urlq.onNext(s)}
-                    suggestions={[]}
-                    keys={databaseKey}
-                    onHeaderClick={this.showHelp}
-                    onRowClick={this.showVariant}/>
+                {table}
             </Grid>
         );
     }

--- a/js/index.js
+++ b/js/index.js
@@ -32,7 +32,7 @@ var databaseKey = require('../databaseKey');
 var {Grid, Col, Row, Navbar, Nav, Table,
     DropdownButton, MenuItem, Modal, Button} = require('react-bootstrap');
 
-var {VariantTable, ResearchVariantTable} = require('./VariantTable');
+var {VariantTable, ResearchVariantTable, research_mode_columns, columns} = require('./VariantTable');
 var VariantSearch = require('./VariantSearch');
 var {Navigation, State, Link, Route, RouteHandler,
     HistoryLocation, run, DefaultRoute} = require('react-router');
@@ -352,18 +352,13 @@ var Database = React.createClass({
     }
 });
 
-var _toSpace = s => s.replace(/_/g, ' ');
-
 var Key = React.createClass({
     render() {
-        var {onClick, tableKey} = this.props,
-            words = tableKey.replace(/_/g, ' ').split(' ');
+        var {onClick, tableKey} = this.props;
         return (
              <td className='help-target'>
-                {words.slice(0, words.length - 1).join(' ')}
-                {' '}
+                {tableKey}
                 <span className="text-nowrap">
-                    {words[words.length - 1]}
                     <span role='button' onClick={onClick}
                         className='help glyphicon glyphicon-question-sign superscript'/>
                 </span>
@@ -381,19 +376,26 @@ var VariantDetail = React.createClass({
         backend.data({
             filterValues: variantPathSplit(this.props.params.id),
             pageLength: 1
-        }).take(1).subscribe(
-            resp => this.setState({data: resp.data[0], error: null}),
+        }).subscribe(
+            resp => {
+                return this.setState({data: resp.data[0], error: null})
+            },
             this.setState({error: 'Problem connecting to server'}));
     },
-    render: function() {
+    render: function () {
         var {data: variant = {}, error} = this.state;
-
-        variant = _.omit(variant, ['__HEADER__']);
-        var rows = _.map(variant, (v, k) =>
-             <tr key={k}>
-                <Key tableKey={k} onClick={() => this.showHelp(_toSpace(k))} />
-                <td>{v}</td>
-             </tr>);
+        var cols;
+        if (localStorage.getItem("research-mode") === true) {
+            cols = research_mode_columns;
+        } else {
+            cols = columns;
+        }
+        var rows = _.map(cols, ({prop, title}) => {
+            return <tr key={prop}>
+                <Key tableKey={title} columns={cols} onClick={() => this.showHelp(title)}/>
+                <td>{variant[prop]}</td>
+            </tr>
+        });
 
 
         return (error ? <p>{error}</p> :


### PR DESCRIPTION
If research mode is on show different column names. Update the column names for both research and non-research mode. Create a component for each mode. Remove the `column_selection` table which was not used, and also remove the `suggestions` property which was not used.